### PR TITLE
fix: handle existing FLAC files when re-ripping an album

### DIFF
--- a/src/cdripper/__init__.py
+++ b/src/cdripper/__init__.py
@@ -396,8 +396,13 @@ def rip_and_encode(device, track_num, output_path, logfile=None, track_label="",
         if drive_state:
             drive_state.update(status="Encoding", speed=0.0, track_progress=1.0)
 
+        # Remove existing FLAC to avoid encoder refusal on re-rip
+        out = Path(output_path)
+        if out.exists():
+            out.unlink()
+
         subprocess.run(
-            ["flac", "-s", "-8", "-o", str(output_path), wav_path],
+            ["flac", "-s", "-8", "--force", "-o", str(output_path), wav_path],
             check=True,
             capture_output=True,
         )
@@ -533,6 +538,8 @@ def rip_disc(disc, device, output_dir, logfile, drive_state=None):
         track_label = f"Track {num:02d}/{total:02d}: {track['title']}"
         fname = _track_filename(track, metadata)
         flac_path = album_dir / fname
+        if flac_path.exists():
+            log(f"  {track_label}: overwriting existing file", logfile, device)
         log(f"  Ripping {track_label}", logfile, device)
 
         expected_wav = track_wav_sizes.get(num, 0)
@@ -550,10 +557,10 @@ def rip_disc(disc, device, output_dir, logfile, drive_state=None):
                 tag_flac(flac_path, metadata, track)
                 success = True
                 break
-            except subprocess.CalledProcessError as e:
+            except (subprocess.CalledProcessError, OSError) as e:
                 if attempt < MAX_TRACK_RETRIES:
-                    log(f"  ERROR on {track_label} (attempt {attempt}/{MAX_TRACK_RETRIES}), "
-                        f"retrying...", logfile, device)
+                    log(f"  ERROR on {track_label} (attempt {attempt}/{MAX_TRACK_RETRIES}): "
+                        f"{e}, retrying...", logfile, device)
                 else:
                     log(f"  FAILED {track_label} after {MAX_TRACK_RETRIES} attempts: {e}",
                         logfile, device)


### PR DESCRIPTION
## Summary
- Remove existing FLAC file before encoding to prevent `flac` encoder refusal on re-rip
- Add `--force` flag to `flac` command as a safety net
- Widen exception handling in retry loop to catch `OSError` alongside `CalledProcessError`
- Log when overwriting existing files, and include error details in retry messages

## Test plan
- [ ] Insert a disc that has already been ripped to the output directory
- [ ] Verify it re-rips cleanly without encoder errors
- [ ] Verify log shows "overwriting existing file" messages
- [ ] Verify retry error messages now include the error detail

Closes #6